### PR TITLE
Deduplicates generated storyboard & xib translation files

### DIFF
--- a/lib/xlocalize/xliff.rb
+++ b/lib/xlocalize/xliff.rb
@@ -55,5 +55,19 @@ module Xlocalize
         node.parent.remove if node.elements.count == 0
       }
     end
+
+    def filter_duplicate_storyboard_xib_files
+      all_files = self.xpath("//xmlns:file").map { |node| Pathname.new(node["original"]).split.last.to_s }
+      self.xpath("//xmlns:file").each do |node|
+        fname = Pathname.new(node["original"]).split.last.to_s
+        if fname.end_with?(".strings")
+          storyboard_fname = fname.sub(".strings", ".storyboard")
+          xib_fname = fname.sub(".strings", ".xib")
+          if all_files.include?(storyboard_fname) || all_files.include?(xib_fname)
+            node.remove
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/xliff_spec.rb
+++ b/spec/xliff_spec.rb
@@ -83,4 +83,25 @@ describe Nokogiri::XML::Document do
     doc.filter_trans_units("##")
     expect(doc.xpath("//xmlns:trans-unit").map { |trans_unit| trans_unit["id"] }).to eq(["valid1", "valid2", "valid3"])
   end
+
+  it 'filters strings files that match storyboard or xib name' do
+    xliff = <<-eos
+    <?xml version="1.0" encoding="UTF-8"?>
+    <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+      <file original="path/to/translations/en.lproj/view.strings" datatype="plaintext" source-language="en"></file>
+      <file original="path/to/xibs/en.lproj/view.xib" datatype="plaintext" source-language="en"></file>
+      <file original="path/to/translations/en.lproj/story.strings" datatype="plaintext" source-language="en"></file>
+      <file original="path/to/storyboards/en.lproj/story.storyboard" datatype="plaintext" source-language="en"></file>
+      <file original="path/to/translations/en.lproj/only_strings.strings" datatype="plaintext" source-language="en"></file>
+    </xliff>
+    eos
+    doc = Nokogiri::XML(xliff)
+    doc.filter_duplicate_storyboard_xib_files
+    expected = [
+      "path/to/xibs/en.lproj/view.xib",
+      "path/to/storyboards/en.lproj/story.storyboard",
+      "path/to/translations/en.lproj/only_strings.strings"
+    ]
+    expect(doc.xpath("//xmlns:file").map { |f| f["original"] }).to eq(expected)
+  end
 end


### PR DESCRIPTION
Since Xcode 9.3 creates duplicate `.strings` files entries in xliff if keys are used in code from storyboard or xib translation file. Basically two identical xml structures are under `.storyboard` / `.xib` and `.strings` entries. Fix filters `.strings` entries if `.storyboard` /& `.xib` exist.