### PR TITLE
Use different {locale}.xliff path on Xcode 9 and Xcode 10

### DIFF
--- a/lib/xlocalize/executor.rb
+++ b/lib/xlocalize/executor.rb
@@ -15,7 +15,11 @@ module Xlocalize
     end
 
     def locale_file_name(locale)
-      return "#{locale}.xliff"
+      if Helper.xcode_at_least?(10)
+        return "#{locale}.xcloc/Localized Contents/#{locale}.xliff"
+      else
+        return "#{locale}.xliff"
+      end
     end
 
     def export_master(wti, project, targets, excl_prefix, master_lang, exclude_units=[], no_cryptic)

--- a/lib/xlocalize/version.rb
+++ b/lib/xlocalize/version.rb
@@ -1,4 +1,4 @@
 module Xlocalize
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
   DESCRIPTION = "Xcode localizations import/export helper tool"
 end

--- a/spec/export_spec.rb
+++ b/spec/export_spec.rb
@@ -32,7 +32,9 @@ describe Xlocalize::Executor do
       export_file = StringIO.new
 
       allow(File).to receive(:exist?).and_return(false)
-      allow(Xlocalize::Helper).to receive(:xcode_at_least?).and_return(true)
+      allow(Xlocalize::Helper).to receive(:xcode_at_least?).with(9).and_return(true)
+      allow(Xlocalize::Helper).to receive(:xcode_at_least?).with(9.3).and_return(true)
+      allow(Xlocalize::Helper).to receive(:xcode_at_least?).with(10).and_return(false)
       allow(Kernel).to receive(:system).with('xcodebuild -exportLocalizations -localizationPath ./ -project Project.xcodeproj')
       allow(File).to receive(:open).with('en.xliff').and_return(xliff)
       allow(File).to receive(:open).with('en.xliff', 'w').and_yield(export_file)


### PR DESCRIPTION
Xcode 10 stores en.xliff file in different location than Xcode 9